### PR TITLE
순위 계산 시 1%가 같은 경우 12%로 비교

### DIFF
--- a/utils/log.ts
+++ b/utils/log.ts
@@ -19,6 +19,9 @@ export const getFourPlayerGameStats = (): FourPlayerGameStat[] => {
 	});
 
 	const statSortFn = (playerA: FourPlayerGameStat, playerB: FourPlayerGameStat) => {
+		if (playerA.firstRatio == playerB.firstRatio) {
+			return playerB.upperSecondRatio - playerA.upperSecondRatio;
+		}
 	  return playerB.firstRatio - playerA.firstRatio;
 	};
 	fourPlayerGameStats.sort(statSortFn).forEach((stat, i) => stat["rank"] = i + 1);


### PR DESCRIPTION
기존에는 1%가 같은 경우 기존 순서대로 순위 매겨짐
12% 추가 비교로 순위 정할 수 있도록 로직 추가