### PR TITLE
1인 플레이 게임 로그는 가져오지 않도록 수정

### DIFF
--- a/log-fetcher/fetch_game_log.py
+++ b/log-fetcher/fetch_game_log.py
@@ -164,6 +164,9 @@ def process_raw_record(raw_record):
         records.append(record)
 
     game_meta_data = json.loads(MessageToJson(raw_record))
+    if len(game_meta_data["head"]["accounts"]) < 3:
+        return False
+
     if "data" in game_meta_data:
         del game_meta_data["data"]
 


### PR DESCRIPTION
1인 플레이 로그도 현재 스크래퍼가 가져오고 있으므로, 해당 로그 거르는 로직 추가