### PR TITLE
이미지 로더 akamai로 교체

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,10 @@ const isProd = process.env.NODE_ENV === 'production';
 const nextConfig = {
   reactStrictMode: true,
   assetPrefix: isProd ? 'https://KOREAN139.github.io/syssec-leaderboard/' : '',
+  images: {
+    loader: 'akamai',
+    path: '/',
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
기존 이미지 로더 + `next/image` 로는 static page 서빙 불가능
이미지 로더 `akamai`로 교체하여 해결